### PR TITLE
Changing font away from Lato

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -3,7 +3,8 @@
 
 @import "{{ site.theme }}";
 html body {
-  font-weight: 450;
+  font-weight: 400;
+  font-family: "Martel Sans","Open Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
   background-color: #183583;
   background-position: center center;
   background-size: cover;


### PR DESCRIPTION
It seems like Lato is going to it's "Light" weight for some reason and only Firefox respects the font-weight directive.

This follows on from https://github.com/manifestoforscalingagility/ManifestoForScalingAgility.github.io/pull/14 and addresses issue https://github.com/manifestoforscalingagility/ManifestoForScalingAgility.github.io/issues/7