### PR TITLE
Revert to normal-weight Lato

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,10 +1,10 @@
 ---
 ---
 
+@import url('https://fonts.googleapis.com/css?family=Lato:400,400i,700,900&display=swap');
 @import "{{ site.theme }}";
 html body {
-  font-weight: 400;
-  font-family: "Martel Sans","Open Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-weight: normal;
   background-color: #183583;
   background-position: center center;
   background-size: cover;


### PR DESCRIPTION
Looks like the real problem is that the theme only loads the 300-weight version of Lato. By loading the 400-weight version, we can actually use the normal weight.

This follows on from https://github.com/manifestoforscalingagility/ManifestoForScalingAgility.github.io/pull/14 and https://github.com/manifestoforscalingagility/ManifestoForScalingAgility.github.io/pull/15 and addresses issue https://github.com/manifestoforscalingagility/ManifestoForScalingAgility.github.io/issues/7