### PR TITLE
Add Gemfile for local testing of site

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+# This Gemfile supports serving the site locally via the following Docker command:
+# docker run -it --rm -v "$PWD":/usr/src/app -p "4000:4000" starefossen/github-pages
+
+source 'https://rubygems.org'
+gem 'github-pages', group: :jekyll_plugins


### PR DESCRIPTION
This Gemfile supports serving the site locally via a Docker command:
```
docker run -it --rm -v "$PWD":/usr/src/app -p "4000:4000" starefossen/github-pages
```

I didn't exactly follow the [Docker image's directions](https://hub.docker.com/r/starefossen/github-pages). I used some [outdated GitHub instructions](https://help.github.com/en/enterprise/2.14/user/articles/setting-up-your-github-pages-site-locally-with-jekyll) for the Gemfile.